### PR TITLE
Deprecate username:password login in favor of access_key:access_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ require 'sumo'
 Your credentials go into the YAML file `~/.sumo_creds`.
 An example YAML file is listed below:
 
-Note: Sumo Logic [deprecated](https://help.sumologic.com/APIs/General-API-Information/API-Authentication) username/password login in favor of [access IDs and access keys](https://help.sumologic.com/Manage/Security/Access-Keys#Generate_Access_Keys). In place of your email use your access ID and in place of your password use your access key below.
+Note: Sumo Logic [deprecated](https://help.sumologic.com/APIs/General-API-Information/API-Authentication) username/password login in favor of [access IDs and access keys](https://help.sumologic.com/Manage/Security/Access-Keys#Generate_Access_Keys).
 
 ```yaml
 backend:
-  email: your_access_id
-  password: your_access_key
+  access_id: your_access_id
+  access_key: your_access_key
 default:
-  email: your_other_access_id
-  password: your_access_key
+  access_id: your_other_access_id
+  access_key: your_access_key
 ```
 
 The credentials in the `default` namespace are loaded by default.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ require 'sumo'
 Your credentials go into the YAML file `~/.sumo_creds`.
 An example YAML file is listed below:
 
+Note: Sumo Logic [deprecated](https://help.sumologic.com/APIs/General-API-Information/API-Authentication) username/password login in favor of [access IDs and access keys](https://help.sumologic.com/Manage/Security/Access-Keys#Generate_Access_Keys). In place of your email use your access ID and in place of your password use your access key below.
+
 ```yaml
 backend:
-  email: email@test.net
-  password: trustno1
+  email: your_access_id
+  password: your_access_key
 default:
-  email: email2@test.net
-  password: test-pass
+  email: your_other_access_id
+  password: your_access_key
 ```
 
 The credentials in the `default` namespace are loaded by default.

--- a/lib/sumo/client.rb
+++ b/lib/sumo/client.rb
@@ -2,7 +2,7 @@
 class Sumo::Client
   include Sumo::Error
 
-  attr_reader :email, :password, :cookie
+  attr_reader :access_id, :access_key, :cookie
 
   REDIRECT_STATUSES = [301, 302, 303, 307, 308]
 
@@ -11,8 +11,8 @@ class Sumo::Client
 
   # Create a new `Sumo::Client` with the given credentials.
   def initialize(credentials = Sumo.creds)
-    @email = credentials['email'].freeze
-    @password = credentials['password'].freeze
+    @access_id = credentials['access_id'].freeze
+    @access_key = credentials['access_key'].freeze
   end
 
   # Send a request to the API and retrieve processed data.
@@ -103,7 +103,7 @@ class Sumo::Client
   private :encoded_creds
 
   def creds
-    [email, password].join(':')
+    [access_id, access_key].join(':')
   end
   private :creds
 

--- a/lib/sumo/error.rb
+++ b/lib/sumo/error.rb
@@ -12,4 +12,7 @@ module Sumo::Error
 
   # Raised when a 5xx-level response is returned by the API.
   class ServerError < BaseError; end
+
+  # Raised when credentials contain deprecated keys
+  class EmailPasswordDeprecated < BaseError; end
 end

--- a/spec/fixtures/deprecated-creds
+++ b/spec/fixtures/deprecated-creds
@@ -1,0 +1,3 @@
+default:
+  email: test@example.com
+  password: trustno1

--- a/spec/fixtures/sumo-creds
+++ b/spec/fixtures/sumo-creds
@@ -1,3 +1,3 @@
 engineering:
-  email: test@example.com
-  password: trustno1
+  access_id: test
+  access_key: trustno1

--- a/spec/lib/sumo/cli_spec.rb
+++ b/spec/lib/sumo/cli_spec.rb
@@ -60,8 +60,8 @@ describe Sumo::CLI do
     context 'when there are credentials' do
       let(:creds) {
         {
-          'email' => 'test@email.net',
-          'password' => 'sumo'
+          'access_id' => 'test',
+          'access_key' => 'sumo'
         }
       }
       let(:messages) { [{ '_raw' => 'first' }, { '_raw' => 'second' }] }

--- a/spec/lib/sumo/client_spec.rb
+++ b/spec/lib/sumo/client_spec.rb
@@ -4,8 +4,8 @@ describe Sumo::Client do
   describe '#initialize' do
     let(:creds) {
       {
-        'email' => 'test@test.com',
-        'password' => 'example'
+        'access_id' => 'test',
+        'access_key' => 'example'
       }
     }
 
@@ -14,8 +14,8 @@ describe Sumo::Client do
       before { Sumo.stub(:creds).and_return(creds) }
 
       it 'sets the default credentials' do
-        subject.email.should == 'test@test.com'
-        subject.password.should == 'example'
+        subject.access_id.should == 'test'
+        subject.access_key.should == 'example'
       end
     end
 
@@ -23,8 +23,8 @@ describe Sumo::Client do
       subject { Sumo::Client.new(creds) }
 
       it 'sets the credentials to that argument' do
-        subject.email.should == 'test@test.com'
-        subject.password.should == 'example'
+        subject.access_id.should == 'test'
+        subject.access_key.should == 'example'
       end
     end
   end
@@ -34,11 +34,11 @@ describe Sumo::Client do
     let(:response) { double(:response) }
     let(:creds) {
       {
-        'email' => 'creds@email.com',
-        'password' => 'test'
+        'access_id' => 'creds',
+        'access_key' => 'test'
       }
     }
-    let(:encoded) { Base64.encode64('creds@email.com:test').strip }
+    let(:encoded) { Base64.encode64('creds:test').strip }
     subject { Sumo::Client.new(creds) }
     before { subject.stub(:connection).and_return(connection) }
 

--- a/spec/lib/sumo/config_spec.rb
+++ b/spec/lib/sumo/config_spec.rb
@@ -26,8 +26,8 @@ describe Sumo::Config, :current do
     context 'when #load_creds! does not raise an error' do
       let(:creds) {
         {
-          :email => 'test@example.com',
-          :password => 'canthackthis'
+          :access_id => 'test',
+          :access_key => 'canthackthis'
         }
       }
       before { subject.stub(:load_creds!).and_return(creds) }
@@ -76,8 +76,8 @@ describe Sumo::Config, :current do
         context 'when the specified key can be found' do
           let(:expected) {
             {
-              'email' => 'test@example.com',
-              'password' => 'trustno1'
+              'access_id' => 'test',
+              'access_key' => 'trustno1'
             }
           }
           before { ENV['SUMO_CREDENTIAL'] = 'engineering' }
@@ -86,6 +86,19 @@ describe Sumo::Config, :current do
           it 'returns those credentials' do
             expect(subject.load_creds!).to eq(expected)
           end
+        end
+      end
+
+      context 'when the file contains deprecated keys' do
+        let(:test_config_file) {
+          File.join(
+            File.dirname(__FILE__), '..', '..', 'fixtures', 'deprecated-creds'
+          )
+        }
+
+        it 'raises an error' do
+          expect { subject.load_creds! }
+            .to raise_error(Sumo::Error::EmailPasswordDeprecated)
         end
       end
     end


### PR DESCRIPTION
Add note about how authenticating with username and password is deprecated.
Explain how to generate an access key/ID and how to use that in the `sumo_creds` file.